### PR TITLE
GWAS filter browser working

### DIFF
--- a/grails-app/controllers/GWASController.groovy
+++ b/grails-app/controllers/GWASController.groovy
@@ -296,6 +296,17 @@ class GWASController {
 
         if (rootNode?.children) {
 
+			def canidateList = rootNode.children
+			def acceptableList = []
+			
+			for (categoryNode in canidateList) {
+				if (acceptableForBrowse(categoryNode)) {
+					acceptableList.add(categoryNode)
+				}
+			}
+			
+			rootNode.children = acceptableList
+			
             def categoriesList = []
             // loop thru all children of root and create a list of categories to be used for initial facet search
             for (categoryNode in rootNode.children) {
@@ -330,7 +341,22 @@ class GWASController {
         response.outputStream << categories?.toString()
 
     }
-
+	
+	/**
+	 * Determine if the given category node is acceptable as a top level node. Must be supported 
+	 * by the GUI and by SOLR. As of July 2014, the only categories supported by the GUI are:
+	 * Analyses, Study, Data Type, Region of Interest, EQTL Transcript Gene; of those only
+	 * items in SearchTaxonomy domain will be recognized. Further, the SOLR queries must also
+	 * be considered.
+	 */
+	def acceptableForBrowse = {categoryNode ->
+		String catName = categoryNode.termName
+		if (["Analyses","Data Type"].contains(catName)){
+			return true;
+		}
+		return false; 
+	}
+	
     /**
      * Create a query string for the category in the form of (<cat1>:"term1" OR <cat1>:"term2")
      */
@@ -484,7 +510,7 @@ class GWASController {
      */
     def executeSOLRFacetedQuery = { solrRequestUrl, solrQueryParams, returnAnalysisIds ->
 
-        println(solrQueryParams)
+        // println(solrQueryParams)
 
         JSONObject facetCounts = new JSONObject()
         //solrQueryParams = "q=(*:*)"


### PR DESCRIPTION
I updated the GWAS controller to set the top-level Filter Options in the filter browse to those that are supported by the GUI, the database (see table searchapp.search_taxonomy), and SOLR (see especially the SORL input query for the rgw core).
