### PR TITLE
Removing bio. from code

### DIFF
--- a/grails-app/controllers/com/recomdata/grails/plugin/gwas/GwasSearchController.groovy
+++ b/grails-app/controllers/com/recomdata/grails/plugin/gwas/GwasSearchController.groovy
@@ -390,7 +390,7 @@ class GwasSearchController {
 
         try {
             //We need to determine the data type of this analysis so we know where to pull the data from.
-            def currentAnalysis = bio.BioAssayAnalysis.get(params.analysisId)
+            def currentAnalysis = BioAssayAnalysis.get(params.analysisId)
 
             def pvalueCutoff = params.double('pvalueCutoff')
             def search = params.search


### PR DESCRIPTION
It was part of an earlier codebase and is now generating errors. Basically I am replacing:
bio.BioAssayAnalysis.get(params.analysisId)

by

BioAssayAnalysis.get(params.analysisId)
