### PR TITLE
Upgrade jquery calls to use uiAutocomplete

### DIFF
--- a/grails-app/views/GWAS/_extSearchField.gsp
+++ b/grails-app/views/GWAS/_extSearchField.gsp
@@ -12,7 +12,7 @@ jQuery(document).ready(function() {
 			jQuery("#" + escapedFieldName).val(id);
 			return false;
 		}
-	}).data("autocomplete")._renderItem = function( ul, item ) {
+	}).data("uiAutocomplete")._renderItem = function( ul, item ) {
 		return jQuery('<li></li>')
 		  .data("item.autocomplete", item )
 		  .append('<a><span class="category-' + item.category.toLowerCase() + '">' + item.category + '&gt;</span>&nbsp;<b>' + item.label + '</b> ' + item.synonyms + '</a>')

--- a/grails-app/views/GWAS/_extTagSearchField.gsp
+++ b/grails-app/views/GWAS/_extTagSearchField.gsp
@@ -21,7 +21,7 @@ jQuery(document).ready(function() {
 			newTag.hide().fadeIn('slow');
 			return false;
 		}
-	}).data("autocomplete")._renderItem = function( ul, item ) {
+	}).data("uiAutocomplete")._renderItem = function( ul, item ) {
 		return jQuery('<li></li>')		
 		  .data("item.autocomplete", item )
 		 .append('<a><span class="category-' + item.category.toLowerCase() + '">' + item.category + '&gt;</span>&nbsp;<b>' + item.label + '</b> ' + item.synonyms + '</a>')

--- a/web-app/js/gwas.js
+++ b/web-app/js/gwas.js
@@ -530,7 +530,7 @@ function addSearchAutoComplete()	{
 			addSearchTerm(searchParam);
 			return false;
 		}
-	}).data("autocomplete")._renderItem = function( ul, item ) {
+	}).data("uiAutocomplete")._renderItem = function( ul, item ) {
 		return jQuery('<li></li>')		
 		  .data("item.autocomplete", item )
 		  .append('<a><span class="category-' + item.category.toLowerCase() + '">' + item.category + '&gt;</span>&nbsp;<b>' + item.label + '</b>&nbsp;' + item.synonyms + '</a>')


### PR DESCRIPTION
jquery 1.10 uses `uiAutocomplete` instead of old `autocomplete` keyword
